### PR TITLE
Use U64 for enums to allow in-memory repr

### DIFF
--- a/codegen/idl/__init__.py
+++ b/codegen/idl/__init__.py
@@ -1,14 +1,15 @@
 # LOCK-BEGIN[imports]: DON'T MODIFY
+import codegen.idl.accounts as accounts
 import codegen.idl.constants as constants
 import codegen.idl.instructions as instructions
-import codegen.idl.accounts as accounts
 import codegen.idl.types as types
 
 from solana.publickey import PublicKey
+from solmate import get_pid_or_default
 
 # LOCK-END
 
 
 # LOCK-BEGIN[program_id]: DON'T MODIFY
-PROGRAM_ID = PublicKey("3b76fNWteyMwHLCMSzD2Ke6Tq5GuLv7fjSNQbXCEFGfq")
+PROGRAM_ID = get_pid_or_default("test", PublicKey("4vY1e8Vu5NEeTdhD9NMUUq6MwzYmFL4kskzmJoeVRMGr"))
 # LOCK-END

--- a/codegen/idl/__init__.py
+++ b/codegen/idl/__init__.py
@@ -10,5 +10,5 @@ from solana.publickey import PublicKey
 
 
 # LOCK-BEGIN[program_id]: DON'T MODIFY
-PROGRAM_ID = PublicKey("Gum5M71ZgGyiashxCYpAF1DNkaZZf5RKfwH9xGAomvJf")
+PROGRAM_ID = PublicKey("3b76fNWteyMwHLCMSzD2Ke6Tq5GuLv7fjSNQbXCEFGfq")
 # LOCK-END

--- a/codegen/idl/__init__.py
+++ b/codegen/idl/__init__.py
@@ -11,5 +11,5 @@ from solmate import get_pid_or_default
 
 
 # LOCK-BEGIN[program_id]: DON'T MODIFY
-PROGRAM_ID = get_pid_or_default("test", PublicKey("4vY1e8Vu5NEeTdhD9NMUUq6MwzYmFL4kskzmJoeVRMGr"))
+PROGRAM_ID = get_pid_or_default("test", PublicKey("7YHfGuLpoqbsN3MFCRqo7Cuu4xr9zWrWdq4q3prbMS7e"))
 # LOCK-END

--- a/codegen/idl/__init__.py
+++ b/codegen/idl/__init__.py
@@ -1,8 +1,8 @@
 # LOCK-BEGIN[imports]: DON'T MODIFY
-import codegen.idl.types as types
-import codegen.idl.accounts as accounts
-import codegen.idl.instructions as instructions
 import codegen.idl.constants as constants
+import codegen.idl.instructions as instructions
+import codegen.idl.accounts as accounts
+import codegen.idl.types as types
 
 from solana.publickey import PublicKey
 
@@ -10,5 +10,5 @@ from solana.publickey import PublicKey
 
 
 # LOCK-BEGIN[program_id]: DON'T MODIFY
-PROGRAM_ID = PublicKey("3tTte8kGgvsSmgRt4D6rC5JbGuELwQgRYDTjuRgD7aHt")
+PROGRAM_ID = PublicKey("Gum5M71ZgGyiashxCYpAF1DNkaZZf5RKfwH9xGAomvJf")
 # LOCK-END

--- a/codegen/idl/accounts.py
+++ b/codegen/idl/accounts.py
@@ -4,7 +4,7 @@ from pod import (
     U64,
     pod,
 )
-from solmate.anchor import Discriminant
+from solmate.anchor import AccountDiscriminant
 from codegen.idl.types.array_of_enum_with_fields import ArrayOfEnumWithFields
 from codegen.idl.types.risk_output_register import RiskOutputRegister
 
@@ -14,8 +14,8 @@ from codegen.idl.types.risk_output_register import RiskOutputRegister
 # LOCK-BEGIN[accounts]: DON'T MODIFY
 @pod
 class Accounts(Enum[U64]):
-    ARRAY_OF_ENUM_WITH_FIELDS = Discriminant(field=ArrayOfEnumWithFields)
-    RISK_OUTPUT_REGISTER = Discriminant(field=RiskOutputRegister)
+    ARRAY_OF_ENUM_WITH_FIELDS = AccountDiscriminant(field=ArrayOfEnumWithFields)
+    RISK_OUTPUT_REGISTER = AccountDiscriminant(field=RiskOutputRegister)
     # LOCK-END
 
     @classmethod

--- a/codegen/idl/accounts.py
+++ b/codegen/idl/accounts.py
@@ -1,12 +1,12 @@
 # LOCK-BEGIN[imports]: DON'T MODIFY
+from codegen.idl.types.array_of_enum_with_fields import ArrayOfEnumWithFields
+from codegen.idl.types.risk_output_register import RiskOutputRegister
 from pod import (
     Enum,
     U64,
     pod,
 )
 from solmate.anchor import AccountDiscriminant
-from codegen.idl.types.array_of_enum_with_fields import ArrayOfEnumWithFields
-from codegen.idl.types.risk_output_register import RiskOutputRegister
 
 # LOCK-END
 

--- a/codegen/idl/instructions/__init__.py
+++ b/codegen/idl/instructions/__init__.py
@@ -1,8 +1,8 @@
 # LOCK-BEGIN[imports]: DON'T MODIFY
+from .instruction_tag import InstructionTag
 from .some_ix_name import (
     SomeIxNameIx,
     some_ix_name,
 )
-from .instruction_tag import InstructionTag
 
 # LOCK-END

--- a/codegen/idl/instructions/instruction_tag.py
+++ b/codegen/idl/instructions/instruction_tag.py
@@ -4,7 +4,7 @@ from pod import (
     U64,
     pod,
 )
-from solmate.anchor import Discriminant
+from solmate.anchor import InstructionDiscriminant
 
 # LOCK-END
 
@@ -12,5 +12,5 @@ from solmate.anchor import Discriminant
 # LOCK-BEGIN[instruction_tag]: DON'T MODIFY
 @pod
 class InstructionTag(Enum[U64]):
-    SOME_IX_NAME = Discriminant()
+    SOME_IX_NAME = InstructionDiscriminant()
     # LOCK-END

--- a/codegen/idl/instructions/some_ix_name.py
+++ b/codegen/idl/instructions/some_ix_name.py
@@ -1,21 +1,21 @@
 # LOCK-BEGIN[imports]: DON'T MODIFY
 import codegen.idl
 
+from .instruction_tag import InstructionTag
+from codegen.idl.types import ArrayOfEnumWithFields
+from dataclasses import dataclass
+from io import BytesIO
+from solana.publickey import PublicKey
 from solana.transaction import (
     AccountMeta,
     TransactionInstruction,
 )
-from solana.publickey import PublicKey
-from dataclasses import dataclass
+from solmate.utils import to_account_meta
 from typing import (
     List,
     Optional,
     Union,
 )
-from codegen.idl.types import ArrayOfEnumWithFields
-from io import BytesIO
-from .instruction_tag import InstructionTag
-from solmate.utils import to_account_meta
 
 # LOCK-END
 

--- a/codegen/idl/instructions/some_ix_name.py
+++ b/codegen/idl/instructions/some_ix_name.py
@@ -66,6 +66,7 @@ def some_ix_name(
     params: ArrayOfEnumWithFields,
     remaining_accounts: Optional[List[AccountMeta]] = None,
     program_id: Optional[PublicKey] = None,
+    **kwargs,
 ):
     if program_id is None:
         program_id = codegen.idl.PROGRAM_ID

--- a/codegen/idl/types/__init__.py
+++ b/codegen/idl/types/__init__.py
@@ -1,8 +1,8 @@
 # LOCK-BEGIN[imports]: DON'T MODIFY
-from .call_back_info import CallBackInfo
-from .enum_with_fields import EnumWithFields
 from .action_status import ActionStatus
 from .array_of_enum_with_fields import ArrayOfEnumWithFields
+from .call_back_info import CallBackInfo
+from .enum_with_fields import EnumWithFields
 from .risk_output_register import RiskOutputRegister
 
 # LOCK-END

--- a/codegen/idl/types/action_status.py
+++ b/codegen/idl/types/action_status.py
@@ -1,7 +1,7 @@
 # LOCK-BEGIN[imports]: DON'T MODIFY
 from pod import (
+    AutoTagType,
     Enum,
-    U8,
     pod,
 )
 
@@ -10,20 +10,20 @@ from pod import (
 
 # LOCK-BEGIN[class(ActionStatus)]: DON'T MODIFY
 @pod
-class ActionStatus(Enum[U8]):
+class ActionStatus(Enum[AutoTagType]):
     APPROVED = None
     NOT_APPROVED = None
     # LOCK-END
 
     @classmethod
-    def _to_bytes_partial(cls, buffer, obj):
+    def _to_bytes_partial(cls, buffer, obj, **kwargs):
         # to modify packing, change this method
-        return super()._to_bytes_partial(buffer, obj)
+        return super()._to_bytes_partial(buffer, obj, **kwargs)
 
     @classmethod
-    def _from_bytes_partial(cls, buffer):
+    def _from_bytes_partial(cls, buffer, **kwargs):
         # to modify unpacking, change this method
-        return super()._from_bytes_partial(buffer)
+        return super()._from_bytes_partial(buffer, **kwargs)
 
     @classmethod
     def to_bytes(cls, obj, **kwargs):

--- a/codegen/idl/types/array_of_enum_with_fields.py
+++ b/codegen/idl/types/array_of_enum_with_fields.py
@@ -1,9 +1,9 @@
 # LOCK-BEGIN[imports]: DON'T MODIFY
+from codegen.idl.types.enum_with_fields import EnumWithFields
 from pod import (
     FixedLenArray,
     pod,
 )
-from codegen.idl.types.enum_with_fields import EnumWithFields
 
 # LOCK-END
 

--- a/codegen/idl/types/enum_with_fields.py
+++ b/codegen/idl/types/enum_with_fields.py
@@ -1,7 +1,7 @@
 # LOCK-BEGIN[imports]: DON'T MODIFY
 from pod import (
+    AutoTagType,
     Enum,
-    U8,
     Variant,
     pod,
 )
@@ -13,20 +13,20 @@ from codegen.idl.types.action_status import ActionStatus
 
 # LOCK-BEGIN[class(EnumWithFields)]: DON'T MODIFY
 @pod
-class EnumWithFields(Enum[U8]):
+class EnumWithFields(Enum[AutoTagType]):
     HEALTH = Variant(field=CallBackInfo)
     LIQUIDATION = Variant(field=ActionStatus)
     # LOCK-END
 
     @classmethod
-    def _to_bytes_partial(cls, buffer, obj):
+    def _to_bytes_partial(cls, buffer, obj, **kwargs):
         # to modify packing, change this method
-        return super()._to_bytes_partial(buffer, obj)
+        return super()._to_bytes_partial(buffer, obj, **kwargs)
 
     @classmethod
-    def _from_bytes_partial(cls, buffer):
+    def _from_bytes_partial(cls, buffer, **kwargs):
         # to modify unpacking, change this method
-        return super()._from_bytes_partial(buffer)
+        return super()._from_bytes_partial(buffer, **kwargs)
 
     @classmethod
     def to_bytes(cls, obj, **kwargs):

--- a/codegen/idl/types/enum_with_fields.py
+++ b/codegen/idl/types/enum_with_fields.py
@@ -1,12 +1,12 @@
 # LOCK-BEGIN[imports]: DON'T MODIFY
+from codegen.idl.types.action_status import ActionStatus
+from codegen.idl.types.call_back_info import CallBackInfo
 from pod import (
     AutoTagType,
     Enum,
     Variant,
     pod,
 )
-from codegen.idl.types.call_back_info import CallBackInfo
-from codegen.idl.types.action_status import ActionStatus
 
 # LOCK-END
 

--- a/codegen/idl/types/risk_output_register.py
+++ b/codegen/idl/types/risk_output_register.py
@@ -1,6 +1,6 @@
 # LOCK-BEGIN[imports]: DON'T MODIFY
-from pod import pod
 from codegen.idl.types.enum_with_fields import EnumWithFields
+from pod import pod
 
 # LOCK-END
 

--- a/codegen/other/__init__.py
+++ b/codegen/other/__init__.py
@@ -7,5 +7,5 @@ from solana.publickey import PublicKey
 
 
 # LOCK-BEGIN[program_id]: DON'T MODIFY
-PROGRAM_ID = PublicKey("3tTte8kGgvsSmgRt4D6rC5JbGuELwQgRYDTjuRgD7aHt")
+PROGRAM_ID = PublicKey("Gum5M71ZgGyiashxCYpAF1DNkaZZf5RKfwH9xGAomvJf")
 # LOCK-END

--- a/codegen/other/__init__.py
+++ b/codegen/other/__init__.py
@@ -7,5 +7,5 @@ from solana.publickey import PublicKey
 
 
 # LOCK-BEGIN[program_id]: DON'T MODIFY
-PROGRAM_ID = PublicKey("Gum5M71ZgGyiashxCYpAF1DNkaZZf5RKfwH9xGAomvJf")
+PROGRAM_ID = PublicKey("3b76fNWteyMwHLCMSzD2Ke6Tq5GuLv7fjSNQbXCEFGfq")
 # LOCK-END

--- a/codegen/other/__init__.py
+++ b/codegen/other/__init__.py
@@ -8,5 +8,5 @@ from solmate import get_pid_or_default
 
 
 # LOCK-BEGIN[program_id]: DON'T MODIFY
-PROGRAM_ID = get_pid_or_default("other", PublicKey("4vY1e8Vu5NEeTdhD9NMUUq6MwzYmFL4kskzmJoeVRMGr"))
+PROGRAM_ID = get_pid_or_default("other", PublicKey("7YHfGuLpoqbsN3MFCRqo7Cuu4xr9zWrWdq4q3prbMS7e"))
 # LOCK-END

--- a/codegen/other/__init__.py
+++ b/codegen/other/__init__.py
@@ -2,10 +2,11 @@
 import codegen.other.types as types
 
 from solana.publickey import PublicKey
+from solmate import get_pid_or_default
 
 # LOCK-END
 
 
 # LOCK-BEGIN[program_id]: DON'T MODIFY
-PROGRAM_ID = PublicKey("3b76fNWteyMwHLCMSzD2Ke6Tq5GuLv7fjSNQbXCEFGfq")
+PROGRAM_ID = get_pid_or_default("other", PublicKey("4vY1e8Vu5NEeTdhD9NMUUq6MwzYmFL4kskzmJoeVRMGr"))
 # LOCK-END

--- a/codegen/other/types/cross_idl_reference_type.py
+++ b/codegen/other/types/cross_idl_reference_type.py
@@ -1,7 +1,7 @@
 # LOCK-BEGIN[imports]: DON'T MODIFY
+from codegen.idl.types.call_back_info import CallBackInfo
 from pod import pod
 from solana.publickey import PublicKey
-from codegen.idl.types.call_back_info import CallBackInfo
 
 # LOCK-END
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Nima Hamidi <hamidi@alumni.stanford.edu>"]
 python = "^3.9"
 solana = "^0.19.0"
 argparse = "^1.4.0"
-pod = {git = "git@github.com:nimily/pod.git", rev = "main"}
+pod = {git = "git@github.com:nimily/pod.git", rev = "jhow/zero-copy"}
 
 [tool.poetry.dev-dependencies]
 pytest = "6.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Nima Hamidi <hamidi@alumni.stanford.edu>"]
 python = "^3.9"
 solana = "^0.19.0"
 argparse = "^1.4.0"
-pod = {git = "git@github.com:nimily/pod.git", rev = "jhow/zero-copy"}
+pod = {git = "https://github.com/nimily/pod.git", rev = "main"}
 
 [tool.poetry.dev-dependencies]
 pytest = "6.2.5"

--- a/solmate/__init__.py
+++ b/solmate/__init__.py
@@ -6,6 +6,7 @@ from pod import get_catalog
 from pod.bytes import BytesPodConverter
 from pod.json import JsonPodConverter
 from solana.publickey import PublicKey
+from solmate.pids import get_pids_or_default, set_pid_by_protocol_name
 
 
 def register_solana_types_converters():

--- a/solmate/__init__.py
+++ b/solmate/__init__.py
@@ -6,7 +6,7 @@ from pod import get_catalog
 from pod.bytes import BytesPodConverter
 from pod.json import JsonPodConverter
 from solana.publickey import PublicKey
-from solmate.pids import get_pids_or_default, set_pid_by_protocol_name
+from solmate.pids import get_pid_or_default, set_pid_by_protocol_name
 
 
 def register_solana_types_converters():

--- a/solmate/__init__.py
+++ b/solmate/__init__.py
@@ -22,6 +22,12 @@ def register_solana_types_converters():
 
             raise ValueError()
 
+        def calc_size(self, type_, obj, **kwargs) -> int:
+            if type_ == PublicKey:
+                return 32
+
+            raise ValueError()
+
         def calc_max_size(self, type_) -> int:
             if type_ == PublicKey:
                 return 32

--- a/solmate/anchor/codegen.py
+++ b/solmate/anchor/codegen.py
@@ -237,8 +237,8 @@ class CodeGen:
 
             else:
                 editor.add_from_import("pod", "Enum")
-                editor.add_from_import("pod", "U8")
-                class_code += [f"class {type_def.name}(Enum[U8]):\n"]
+                editor.add_from_import("pod", "U64")
+                class_code += [f"class {type_def.name}(Enum[U64]):\n"]
                 variants = type_def.type.field.variants
                 for variant in variants:
                     if variant.fields is None:

--- a/solmate/anchor/codegen.py
+++ b/solmate/anchor/codegen.py
@@ -580,8 +580,9 @@ class CodeGen:
         self._package_editor = self._get_editor(self.root_module, is_file=False)
 
         self._package_editor.add_from_import("solana.publickey", "PublicKey")
+        self._package_editor.add_from_import("solmate", "get_pid_or_default")
         self._package_editor.set_with_lock(
-            "program_id", [f'PROGRAM_ID = PublicKey("{self.program_id}")\n']
+            "program_id", [f'PROGRAM_ID = get_pid_or_default("{self.idl.name}", PublicKey("{self.program_id}")\n']
         )
 
         self._generate_types()

--- a/solmate/anchor/codegen.py
+++ b/solmate/anchor/codegen.py
@@ -582,7 +582,7 @@ class CodeGen:
         self._package_editor.add_from_import("solana.publickey", "PublicKey")
         self._package_editor.add_from_import("solmate", "get_pid_or_default")
         self._package_editor.set_with_lock(
-            "program_id", [f'PROGRAM_ID = get_pid_or_default("{self.idl.name}", PublicKey("{self.program_id}")\n']
+            "program_id", [f'PROGRAM_ID = get_pid_or_default("{self.idl.name}", PublicKey("{self.program_id}"))\n']
         )
 
         self._generate_types()

--- a/solmate/anchor/codegen.py
+++ b/solmate/anchor/codegen.py
@@ -118,14 +118,14 @@ class CodeGen:
             editor.add_lines(
                 "\n",
                 "    @classmethod\n",
-                "    def _to_bytes_partial(cls, buffer, obj):\n",
+                "    def _to_bytes_partial(cls, buffer, obj, **kwargs):\n",
                 "        # to modify packing, change this method\n",
-                "        return super()._to_bytes_partial(buffer, obj)\n",
+                "        return super()._to_bytes_partial(buffer, obj, **kwargs)\n",
                 "\n",
                 "    @classmethod\n",
-                "    def _from_bytes_partial(cls, buffer):\n",
+                "    def _from_bytes_partial(cls, buffer, **kwargs):\n",
                 "        # to modify unpacking, change this method\n",
-                "        return super()._from_bytes_partial(buffer)\n",
+                "        return super()._from_bytes_partial(buffer, **kwargs)\n",
             )
 
         editor.add_lines(
@@ -237,8 +237,8 @@ class CodeGen:
 
             else:
                 editor.add_from_import("pod", "Enum")
-                editor.add_from_import("pod", "U64")
-                class_code += [f"class {type_def.name}(Enum[U64]):\n"]
+                editor.add_from_import("pod", "AutoTagType")
+                class_code += [f"class {type_def.name}(Enum[AutoTagType]):\n"]
                 variants = type_def.type.field.variants
                 for variant in variants:
                     if variant.fields is None:

--- a/solmate/anchor/codegen.py
+++ b/solmate/anchor/codegen.py
@@ -480,6 +480,7 @@ class CodeGen:
 
         for arg_name, arg_type, arg_val in args_with_default:
             code.append(f"    {arg_name}: {arg_type} = {arg_val},\n")
+        code.append(f"    **kwargs,\n")
 
         code.append(f"):\n")
 

--- a/solmate/anchor/editor.py
+++ b/solmate/anchor/editor.py
@@ -31,13 +31,13 @@ class ImportCollector:
     def as_source_code(self):
         code = []
 
-        for import_clause in self._imports:
+        for import_clause in sorted(self._imports):
             code.append(f"import {import_clause}\n")
 
         if self._imports:
             code.append("\n")
 
-        for from_clause, import_clauses in self._from_imports.items():
+        for from_clause, import_clauses in sorted(self._from_imports.items()):
             if len(import_clauses) == 1:
                 code.append(f"from {from_clause} import {list(import_clauses)[0]}\n")
             else:

--- a/solmate/dtypes.py
+++ b/solmate/dtypes.py
@@ -1,6 +1,6 @@
 from typing import Type
 
-from pod import U32, U64, I64, Enum, Variant, Option, pod
+from pod import U32, U64, I64, Enum, Variant, Option, pod, AutoTagType
 from pod._utils import _GetitemToCall, get_calling_module
 
 
@@ -65,7 +65,7 @@ class ProgramError(Enum):
 
 def _coption(name, type_: Type):
     @pod
-    class _COption(Enum[U32]):
+    class _COption(Enum[AutoTagType]):
         NONE = Variant()
         SOME = Variant(field=type_, module=get_calling_module(4))
 

--- a/solmate/pids.py
+++ b/solmate/pids.py
@@ -1,0 +1,13 @@
+from solana.publickey import PublicKey
+
+_PIDS = dict()
+
+
+def get_pids_or_default(protocol_name: str, default: PublicKey):
+    global _PIDS
+    return _PIDS.get(key=protocol_name, default=default)
+
+
+def set_pid_by_protocol_name(protocol_name: str, pid: PublicKey):
+    global _PIDS
+    _PIDS[protocol_name] = pid

--- a/solmate/pids.py
+++ b/solmate/pids.py
@@ -1,11 +1,12 @@
 from solana.publickey import PublicKey
+from typing import Dict
 
-_PIDS = dict()
+_PIDS: Dict[str, PublicKey] = dict()
 
 
-def get_pids_or_default(protocol_name: str, default: PublicKey):
+def get_pid_or_default(protocol_name: str, default: PublicKey):
     global _PIDS
-    return _PIDS.get(key=protocol_name, default=default)
+    return _PIDS.get(protocol_name, default)
 
 
 def set_pid_by_protocol_name(protocol_name: str, pid: PublicKey):

--- a/tests/anchor/test_integration.py
+++ b/tests/anchor/test_integration.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from solana.keypair import Keypair
 
 from solmate.anchor import codegen
-
+from pod import Static
 
 def get_project_root() -> Path:
     return Path(__file__).parent.parent.parent
@@ -15,13 +15,39 @@ def test():
     pids = {"idl": keypair.public_key, "other": keypair.public_key}
     codegen.cli(f"{root}/tests/anchor", root, pids, "codegen", set())
 
-    from codegen.idl.types import CallBackInfo
+    from codegen.idl.types import CallBackInfo, EnumWithFields
     from codegen.other.types.cross_idl_reference_type import CrossIdlReferenceType
 
     info = CallBackInfo(keypair.public_key, 129)
     _bytes = CallBackInfo.to_bytes(info)
     round_tripped = CallBackInfo.from_bytes(_bytes)
     assert info == round_tripped
+
+    enum = EnumWithFields.HEALTH(info)
+    _bytes = EnumWithFields.to_bytes(enum, format="FORMAT_BORSCH")
+    round_tripped = EnumWithFields.from_bytes(_bytes)
+    assert enum == round_tripped
+    try:
+        round_tripped = EnumWithFields.from_bytes(_bytes, format="FORMAT_ZERO_COPY")
+        print(round_tripped)
+        excepted = False
+    except Exception:
+        excepted = True
+    finally:
+        assert excepted
+
+    enum = EnumWithFields.HEALTH(info)
+    _bytes = EnumWithFields.to_bytes(enum, format="FORMAT_ZERO_COPY")
+    round_tripped = EnumWithFields.from_bytes(_bytes)
+    assert enum == round_tripped
+    try:
+        EnumWithFields.from_bytes(_bytes, format="FORMAT_BORSCH", checked=True)
+        excepted = False
+    except Exception:
+        excepted = True
+    finally:
+        assert excepted
+
 
     reference_type = CrossIdlReferenceType(keypair.public_key, info)
     _bytes = CrossIdlReferenceType.to_bytes(reference_type)


### PR DESCRIPTION
This is needed for dexterity but doesn't have to merge into main since it would break borsch compatibility 
Not sure what the final solution looks like here. 
The repr of enums changes based off of borsch vs. in-memory serialization format but nothing else changes. One possibility is introducing an "Auto" tag type for enums that can change depending on the serialization format. 
For Borsch it would be U8, for in-memory it would be U64, for json it would be `num` or whatever 