### PR TITLE
better handling of enum struct variants and a bit more testing

### DIFF
--- a/solmate/anchor/codegen.py
+++ b/solmate/anchor/codegen.py
@@ -515,7 +515,7 @@ class CodeGen:
                         if len(named_fields) == 0:
                             variant_type = "None"
                         else:
-                            variant_type = "Variant(field=Option[named_fields(" + ", ".join(named_fields) + ")])"
+                            variant_type = "Variant(field=named_fields(" + ", ".join(named_fields) + "))"
                     else:
                         editor.add_from_import("podite", "Variant")
 

--- a/tests/anchor/idl.json
+++ b/tests/anchor/idl.json
@@ -180,6 +180,17 @@
                 "type": "u64"
               }
             ]
+          },
+          {
+            "name": "OptionalVariant",
+            "fields": [
+              {
+                "name": "opt",
+                "type": {
+                  "option": "u128"
+                }
+              }
+            ]
           }
         ]
       }

--- a/tests/anchor/test_integration.py
+++ b/tests/anchor/test_integration.py
@@ -6,6 +6,7 @@ import tests.anchor.cross_idl_cli as cross_idl_cli
 
 from solana.keypair import Keypair
 
+from podite import U128
 
 
 def get_project_root() -> Path:
@@ -57,11 +58,13 @@ def test():
     round_tripped = CrossIdlReferenceType.from_bytes(_bytes)
     assert reference_type == round_tripped
 
-    OptionalSomeType = Option[SomeType]
-    enum_struct = EnumWithStructVariant.STRUCT_VARIANT(OptionalSomeType.SOME((SomeType(5), )))
+    enum_struct = EnumWithStructVariant.STRUCT_VARIANT((SomeType(5), ))
     _bytes = EnumWithStructVariant.to_bytes(enum_struct, format="FORMAT_ZERO_COPY")
     round_tripped = EnumWithStructVariant.from_bytes(_bytes)
-    assert enum_struct.field.field == round_tripped.field.field
+    assert enum_struct == round_tripped
 
-    # the following currently doesn't work due to an issue with __eq__
-    # assert enum_struct == round_tripped
+    OptionalU128 = Option[U128]
+    enum_struct_optional = EnumWithStructVariant.OPTIONAL_VARIANT((OptionalU128.SOME(42), ))
+    _bytes = EnumWithStructVariant.to_bytes(enum_struct_optional, format="FORMAT_ZERO_COPY")
+    round_tripped = EnumWithStructVariant.from_bytes(_bytes)
+    assert enum_struct_optional == round_tripped


### PR DESCRIPTION
@nimily @JoeHowarth after we merged the previous PR for enums with struct variants I realized it was actually blowing up with our client code - I am not sure how I ever convinced myself it was fine. This removed the hardcoded optionality of the struct variant and tests both cases.